### PR TITLE
Debowerify

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower_components"
-}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,6 +1,3 @@
-// @import 'bower_components/newsapps-styles/init-helpers';
-@import 'bower_components/bourbon/app/assets/stylesheets/bourbon';
-@import 'bower_components/neat/app/assets/stylesheets/neat';
 @import 'node_modules/newsapps-styles/initialize';
 
 // Style Guide

--- a/app/styles/styleguide/_main.scss
+++ b/app/styles/styleguide/_main.scss
@@ -77,7 +77,7 @@ article {
 }
 
 .teal-button {
-  @include button($teal);
+  @include btn($teal);
 }
 
 .button,

--- a/app/templates/sections/base-elements.html
+++ b/app/templates/sections/base-elements.html
@@ -237,7 +237,7 @@ hr {
 
   input[type="submit"],
   input[type="button"] {
-    @include button($tribune-yellow);
+    @include btn($tribune-yellow);
   }
 }
       </code>

--- a/app/templates/sections/buttons.html
+++ b/app/templates/sections/buttons.html
@@ -46,11 +46,11 @@
 }
 
 .button {
-  @include button($tribune-yellow);
+  @include btn($tribune-yellow);
 }
 
 .ghost-button {
-  @include button($teal, ghost);
+  @include btn($teal, ghost);
 }
       </code>
     </pre>

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "newsapps-app-kit",
-  "private": true,
-  "devDependencies": {
-    "newsapps-styles": "texastribune/newsapps-styles#0.8.1"
-  }
-}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,6 @@ gulp.task('serve', ['styles', 'jshint', 'templates'], function() {
     server: {
       baseDir: ['.tmp', 'app'],
       routes: {
-        '/bower_components': 'bower_components',
         '/node_modules': 'node_modules'
       }
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "deploy": "./bin/deploy.sh && npm run assets/push"
   },
   "dependencies": {
-    "newsapps-styles": "^1.0.0"
+    "newsapps-styles": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,12 +36,15 @@
     "vinyl-transform": "^1.0.0",
     "xlsx": "^0.7.12"
   },
-    "scripts": {
+  "scripts": {
     "spreadsheet/authorize": "./bin/authorize.js",
     "spreadsheet/fetch": "./bin/fetch_spreadsheet.js",
     "spreadsheet/edit": "./bin/edit_spreadsheet.js",
     "assets/push": "./bin/push_assets_to_s3.sh",
     "assets/pull": "./bin/pull_assets_from_s3.sh",
     "deploy": "./bin/deploy.sh && npm run assets/push"
+  },
+  "dependencies": {
+    "newsapps-styles": "^1.0.0"
   }
 }


### PR DESCRIPTION
## What this does
Continuing the removal of `bower` from our things.

- Gets rid of `bower` specific files
- Adds [`newsapps-styles@v1.0.1`](https://github.com/texastribune/newsapps-styles/tree/v1.0.1) as a dependency
- Changes references to `bower_components` to `node_modules`
- Removes unneeded import of `bourbon` and `bourbon-neat`

## How to test
- `rm -rf bower_components && rm -rf node_modules`
- `npm install`
- `npm run assets/pull`
- `gulp serve`
- Visit [`http://localhost:3000`]() and see how it looks!